### PR TITLE
billing record issues fixed

### DIFF
--- a/src/billing/billing.service.ts
+++ b/src/billing/billing.service.ts
@@ -32,7 +32,7 @@ export class BillingService {
       data: {
         reservationId: dto.reservationId,
         amount: dto.amount,
-        paymentMethod: dto.paymentMethod as any, // Cast to enum
+        paymentMethod: 'COMPANY', // Changed to correct enum value
       },
     });
   }


### PR DESCRIPTION
This pull request includes a small change to the billing logic. The `paymentMethod` field is now set to the correct enum value `'COMPANY'` instead of casting from the DTO, ensuring more reliable and explicit billing behavior.